### PR TITLE
Refactor togglecolumns plugin to work externally

### DIFF
--- a/lib/tabler/tabler.toggleColumns.js
+++ b/lib/tabler/tabler.toggleColumns.js
@@ -121,12 +121,13 @@
         $a.html($li.is('.closed') ? '+' : '&ndash;');
     });
     $toggleUI.delegate('button.apply', 'click', function(e){
-        var table = $toggleUI.data('table');
+        var table = $toggleUI.data('table'),
+            toggleColumns = $toggleUI.data('toggleColumns');
 
         e.preventDefault();
 
         $toggleUI.find('input[type=checkbox][name=column]').each(function(i, el){
-            var field = table.getField($(el).val()) || table.toggleColumns.getCustomColumn({
+            var field = table.getField($(el).val()) || toggleColumns.getCustomColumn({
                 id: $(el).val()
             });
 
@@ -145,6 +146,9 @@
 
     function ToggleColumns(options){
         this.options = options || {};
+        this.customColumns = [];
+        this.groupFormatters = {};
+        this.formatters = {};
     }
     ToggleColumns.pluginName = 'toggleColumns';
 
@@ -156,14 +160,105 @@
                 });
             });
         },
+        show: function(options){
+            if(!options.table){
+                throw new Error('options.table is required');
+            }
+            if(!options.$showtrigger){
+                throw new Error('options.$showtrigger is required');
+            }
+
+            var table = options.table,
+                $button = options.$showtrigger,
+                customColumns = this.customColumns,
+                buttonOffset,
+                self = this;
+
+            if($toggleUI.closest('html').length){
+                $toggleUI.removeData('table');
+                $toggleUI.detach();
+                return;
+            }
+
+            findNearestScrollingParent(table.$el)
+                 .one('scroll.tablerToggleColumns', detachToggleUI);
+            $(window).one('resize.tablerToggleColumns', detachToggleUI);
+            $('body').one('click.tablerToggleColumns', hideToggleUIFromClick);
+
+            $toggleUI.data('table', table);
+            $toggleUI.data('toggleColumns', this);
+            $toggleUI.find('button.apply').prop('disabled', false);
+            $toggleUI.find('ul.columns').html(_(customColumns).chain()
+                    .union(table.spec)
+                    .filter(function(spec){
+                        return spec.toggleable !== false;
+                    })
+                    .groupBy(function(spec){
+                        return spec.groupName || '';
+                    })
+                    .map(function(group, name){
+                        var html = [],
+                            id = _.uniqueId('toggleColumnsUIGroup'),
+                            anyChecked, allChecked,
+                            displayText,
+                            groupFormatter;
+
+                        if(name){
+                            groupFormatter = self.groupFormatters[name] || defaultGroupFormatter;
+                            displayText = groupFormatter(name);
+
+                            anyChecked = _(group).any(function(spec){return !spec.disabled;});
+                            allChecked = _(group).all(function(spec){return !spec.disabled;});
+
+                            html.push('<li class="columnGroup closed">');
+                            html.push('<a href="#" class="opener">+</a>');
+                            html.push('<input name=columnGroup type=checkbox value="" id="' + _.escape(id) + '" ' +
+                                    (anyChecked ? 'checked' : '') + ' ' +
+                                    (allChecked ? '' : 'class="partiallySelected"') + '/>');
+                            html.push('<label for="' + _.escape(id) + '">' + displayText + '</label>');
+                            html.push('<ul>');
+                        }
+
+                        html = html.concat(_(group).map(function(spec){
+                            var id = _.uniqueId('toggleColumnsUIValue'),
+                                columnFormatter = self.formatters[spec.id || spec.field] || defaultFormatter,
+                                displayText = columnFormatter(spec);
+
+                            return ['<li><input name=column type=checkbox value="',
+                                        _.escape(spec.id || spec.name),
+                                            '" id="', _.escape(id), '" ',
+                                            (spec.disabled ? '' : ' checked'),
+                                        ' />',
+                                        '<label for="',
+                                            id,
+                                        '">', displayText, '</label>',
+                                    '</li>'].join('');
+                        }));
+
+                        if(name){
+                            html.push('</ul>');
+                            html.push('</li>');
+                        }
+
+                        return html;
+                    })
+                    .flatten()
+                    .value().join('\n'));
+
+            buttonOffset = $button.offset();
+            $toggleUI
+                .appendTo('body')
+                .css({
+                    left: buttonOffset.left - $toggleUI.outerWidth() + $button.outerWidth(),
+                    top: buttonOffset.top + $button.outerHeight()
+                })
+                .show();
+        },
         attach: function(table){
             var self = this,
                 renderHead = this.originalRenderHead = table.renderHead;
 
             this.table = table;
-            this.customColumns = [];
-            this.groupFormatters = {};
-            this.formatters = {};
 
             table.renderHead = function(data, spec){
                 var html = ['<tr class=toggleColumns>', '<th colspan="' + spec.length + '">',
@@ -175,92 +270,15 @@
             };
 
             table.$el.on('click', '.toggleColumns th button.showHide', function(e){
-                var $button = $(e.target),
-                    buttonOffset;
-
-                if($toggleUI.closest('html').length){
-                    $toggleUI.removeData('table');
-                    $toggleUI.detach();
-                    return;
-                }
-
-                findNearestScrollingParent(table.$el)
-                    .one('scroll.tablerToggleColumns', detachToggleUI);
-                $(window).one('resize.tablerToggleColumns', detachToggleUI);
-                $('body').one('click.tablerToggleColumns', hideToggleUIFromClick);
-
-                $toggleUI.data('table', table);
-                $toggleUI.find('button.apply').prop('disabled', false);
-                $toggleUI.find('ul.columns').html(_(table.toggleColumns.customColumns).chain()
-                        .union(table.spec)
-                        .filter(function(spec){
-                            return spec.toggleable !== false;
-                        })
-                        .groupBy(function(spec){
-                            return spec.groupName || '';
-                        })
-                        .map(function(group, name){
-                            var html = [],
-                                id = _.uniqueId('toggleColumnsUIGroup'),
-                                anyChecked, allChecked,
-                                displayText,
-                                groupFormatter;
-
-                            if(name){
-                                groupFormatter = self.groupFormatters[name] || defaultGroupFormatter;
-                                displayText = groupFormatter(name);
-
-                                anyChecked = _(group).any(function(spec){return !spec.disabled;});
-                                allChecked = _(group).all(function(spec){return !spec.disabled;});
-
-                                html.push('<li class="columnGroup closed">');
-                                html.push('<a href="#" class="opener">+</a>');
-                                html.push('<input name=columnGroup type=checkbox value="" id="' + _.escape(id) + '" ' +
-                                        (anyChecked ? 'checked' : '') + ' ' +
-                                        (allChecked ? '' : 'class="partiallySelected"') + '/>');
-                                html.push('<label for="' + _.escape(id) + '">' + displayText + '</label>');
-                                html.push('<ul>');
-                            }
-
-                            html = html.concat(_(group).map(function(spec){
-                                var id = _.uniqueId('toggleColumnsUIValue'),
-                                    columnFormatter = self.formatters[spec.id || spec.field] || defaultFormatter,
-                                    displayText = columnFormatter(spec);
- 
-                                return ['<li><input name=column type=checkbox value="',
-                                            _.escape(spec.id || spec.name),
-                                                '" id="', _.escape(id), '" ',
-                                                (spec.disabled ? '' : ' checked'),
-                                            ' />',
-                                            '<label for="',
-                                                id,
-                                            '">', displayText, '</label>',
-                                        '</li>'].join('');
-                            }));
-
-                            if(name){
-                                html.push('</ul>');
-                                html.push('</li>');
-                            }
-
-                            return html;
-                        })
-                        .flatten()
-                        .value().join('\n'));
-
-                buttonOffset = $button.offset();
-                $toggleUI
-                    .appendTo('body')
-                    .css({
-                        left: buttonOffset.left - $toggleUI.outerWidth() + $button.outerWidth(),
-                        top: buttonOffset.top + $button.outerHeight()
-                    })
-                    .show();
+                var $showtrigger = $(e.target);
+                self.show({
+                    table : table,
+                    $showtrigger: $showtrigger
+                });
             });
         },
         detach: function(table){
             $toggleUI.detach().removeData('table');
-
             table.renderHead = this.originalRenderHead;
             this.originalRenderHead = undefined;
 


### PR DESCRIPTION
@spmason please review, low priority from Funky Friday.

I have refactored the toggle columns plugin to allow it to be triggered by an element outside of the table.

Initialising a view that uses ToggleColumns:

``` javascript
var toggleColumns = this.toggleColumns = new ToggleColumns();
toggleColumns.customColumns.push({id: 'snippets', name: 'Show snippets'});
```

Opening the ToggleColumns menu in response to a click event:

``` javascript
toggleColumns.show({
    table: table,
    $showtrigger: $(e.target)
});
```
