### PR TITLE
Fixed additional class names issues

### DIFF
--- a/lib/tabler/tabler.columnGrouper.js
+++ b/lib/tabler/tabler.columnGrouper.js
@@ -19,6 +19,7 @@
 
         this.formatters = this.options.formatters || {};
         this.headerCellClassNames = this.options.headerCellClassNames || {};
+        this.groupHeaderCellClassName = this.options.groupHeaderCellClassName;
         this.firstCellInGroupClassName = this.options.firstCellInGroupClassName;
         this.lastCellInGroupClassName = this.options.lastCellInGroupClassName;
     }
@@ -70,9 +71,12 @@
                             var formatter = self.formatters[groupSpec.groupName] || defaultFormatter,
                                 className = self.headerCellClassNames[groupSpec.groupName] || '';
 
+                            className = className || groupSpec.groupName.replace(/\s/g, '-').toLowerCase();
+                            className += ' ' + (self.groupHeaderCellClassName || '');
+
                             return table.makeTag('th', formatter(groupSpec), {
                                 colspan: groupSpec.count,
-                                'class': className || groupSpec.groupName.replace(/\s/g, '-').toLowerCase()
+                                'class': className.trim()
                             });
                         })
                         .value().join('\n') + '</tr>';
@@ -80,24 +84,34 @@
                 return head + renderHead.apply(this, arguments);
             };
             table.makeHeaderAttrs = function(colSpec){
+                var attrs = makeHeaderAttrs.apply(this, arguments),
+                    className = attrs['class'];
+
                 if(self.firstCellInGroupClassName && isFirstColumnInGroup(colSpec)){
-                    colSpec.headerClassName = (colSpec.headerClassName || '') + ' ' + self.firstCellInGroupClassName;
+                    className += ' ' + self.firstCellInGroupClassName;
                 }
                 if(self.lastCellInGroupClassName && isLastColumnInGroup(colSpec)){
-                    colSpec.headerClassName = (colSpec.headerClassName || '') + ' ' + self.lastCellInGroupClassName;
+                    className += ' ' + self.lastCellInGroupClassName;
                 }
 
-                return makeHeaderAttrs.apply(this, arguments);
+                attrs['class'] = className.trim();
+
+                return attrs;
             };
             table.makeColumnAttrs = function(colSpec){
+                var attrs = makeColumnAttrs.apply(this, arguments),
+                    className = attrs['class'];
+
                 if(self.firstCellInGroupClassName && isFirstColumnInGroup(colSpec)){
-                    colSpec.className = (colSpec.className || '') + ' ' + self.firstCellInGroupClassName;
+                    className += ' ' + self.firstCellInGroupClassName;
                 }
                 if(self.lastCellInGroupClassName && isLastColumnInGroup(colSpec)){
-                    colSpec.className = (colSpec.className || '') + ' ' + self.lastCellInGroupClassName;
+                    className += ' ' + self.lastCellInGroupClassName;
                 }
 
-                return makeColumnAttrs.apply(this, arguments);
+                attrs['class'] = className.trim();
+
+                return attrs;
             };
         },
         detach: function(table){

--- a/lib/tabler/tabler.js
+++ b/lib/tabler/tabler.js
@@ -262,9 +262,13 @@ MicroEvent.mixin    = function(destObject){
          * Builds the standard attributes for a column - here mostly for plugins to be able to override
         **/
         makeColumnAttrs: function(colSpec){
+            var className = (colSpec.className || '');
+            if(this.cellClassName){
+                className += ' ' + this.cellClassName;
+            }
             return {
                 width: colSpec.width,
-                'class': (colSpec.className || '').trim()
+                'class': className.trim()
             };
         },
 
@@ -435,9 +439,6 @@ MicroEvent.mixin    = function(destObject){
             })).concat('</tr>').join('\n');
         },
         renderCell: function(row, colSpec, index){
-            if(this.cellClassName){
-                colSpec.className = (colSpec.className || '') + ' ' + this.cellClassName;
-            }
             return this.makeTag('td', this.formatValue(row, colSpec, index), this.makeColumnAttrs(colSpec));
         },
         /*

--- a/test/tabler.columnGrouper.tests.js
+++ b/test/tabler.columnGrouper.tests.js
@@ -87,7 +87,7 @@ define([
             expect(table.$('thead tr:first th').length).toEqual(1);
             expect(table.$('thead tr:first th').html().toLowerCase()).toEqual('<span>group 1 spans 2 columns</span>');
         });
-        it('can take classname to add to each group header cell', function(){
+        it('can take classname to add to every group header cell', function(){
             table = tabler.create([
                 {field: 'column1', name: 'Column 1', groupName: 'Group 1'},
                 {field: 'column2', name: 'Column 2', groupName: 'Group 1'}
@@ -107,6 +107,45 @@ define([
 
             expect(table.$('thead tr:first th').attr('class')).toEqual('foo');
         });
+        it('can take classname to add to specific group header cell', function(){
+            table = tabler.create([
+                {field: 'column1', name: 'Column 1', groupName: 'Group 1'},
+                {field: 'column2', name: 'Column 2', groupName: 'Group 1'}
+            ], {
+                plugins: [columnGrouper],
+                columnGrouper: {
+                    groupHeaderCellClassName: 'columngroupheader'
+                }
+            });
+            table.load([
+                {column1: 'column 1a', column2: 'column 2a'},
+                {column1: 'column 1b', column2: 'column 2b'}
+            ]);
+            table.render();
+
+            expect(table.$('thead tr:first th').attr('class')).toEqual('group-1 columngroupheader');
+        });
+        it('can combine classname to add to every group and specific group header cell', function(){
+            table = tabler.create([
+                {field: 'column1', name: 'Column 1', groupName: 'Group 1'},
+                {field: 'column2', name: 'Column 2', groupName: 'Group 1'}
+            ], {
+                plugins: [columnGrouper],
+                columnGrouper: {
+                    groupHeaderCellClassName: 'columngroupheader',
+                    headerCellClassNames: {
+                        'Group 1': 'foo'
+                    }
+                }
+            });
+            table.load([
+                {column1: 'column 1a', column2: 'column 2a'},
+                {column1: 'column 1b', column2: 'column 2b'}
+            ]);
+            table.render();
+
+            expect(table.$('thead tr:first th').attr('class')).toEqual('foo columngroupheader');
+        });
         it('can add a classname to the first cell in every column group', function(){
             table = tabler.create([
                 {id: 1, field: 'column1', name: 'Column 1a', groupName: 'Group 1'},
@@ -115,6 +154,7 @@ define([
                 {id: 4, field: 'column2', name: 'Column 2b', groupName: 'Group 2'}
             ], {
                 plugins: [columnGrouper],
+                cellClassName: 'cell',
                 columnGrouper: {
                     firstCellInGroupClassName: 'fist'
                 }
@@ -130,10 +170,10 @@ define([
             expect(table.$('thead tr:eq(1) th:eq(1)').attr('class')).toBeFalsey();
             expect(table.$('thead tr:eq(1) th:eq(2)').attr('class')).toEqual('fist');
             expect(table.$('thead tr:eq(1) th:eq(3)').attr('class')).toBeFalsey();
-            expect(table.$('tbody tr:first td:eq(0)').attr('class')).toEqual('fist');
-            expect(table.$('tbody tr:first td:eq(1)').attr('class')).toBeFalsey();
-            expect(table.$('tbody tr:first td:eq(2)').attr('class')).toEqual('fist');
-            expect(table.$('tbody tr:first td:eq(3)').attr('class')).toBeFalsey();
+            expect(table.$('tbody tr:first td:eq(0)').attr('class')).toEqual('cell fist');
+            expect(table.$('tbody tr:first td:eq(1)').attr('class')).toEqual('cell');
+            expect(table.$('tbody tr:first td:eq(2)').attr('class')).toEqual('cell fist');
+            expect(table.$('tbody tr:first td:eq(3)').attr('class')).toEqual('cell');
         });
         it('can add a classname to the first cell in every column group, regardless of disabled state', function(){
             table = tabler.create([
@@ -143,6 +183,7 @@ define([
                 {id: 4, field: 'column2', name: 'Column 2b', groupName: 'Group 2'}
             ], {
                 plugins: [columnGrouper],
+                cellClassName: 'cell',
                 columnGrouper: {
                     firstCellInGroupClassName: 'fist'
                 }
@@ -156,8 +197,8 @@ define([
 
             expect(table.$('thead tr:eq(1) th:eq(0)').attr('class')).toEqual('fist');
             expect(table.$('thead tr:eq(1) th:eq(1)').attr('class')).toEqual('fist');
-            expect(table.$('tbody tr:first td:eq(0)').attr('class')).toEqual('fist');
-            expect(table.$('tbody tr:first td:eq(1)').attr('class')).toEqual('fist');
+            expect(table.$('tbody tr:first td:eq(0)').attr('class')).toEqual('cell fist');
+            expect(table.$('tbody tr:first td:eq(1)').attr('class')).toEqual('cell fist');
         });
         it('can add a classname to the last cell in every column group', function(){
             table = tabler.create([
@@ -167,6 +208,7 @@ define([
                 {id: 4, field: 'column2', name: 'Column 2b', groupName: 'Group 2'}
             ], {
                 plugins: [columnGrouper],
+                cellClassName: 'cell',
                 columnGrouper: {
                     lastCellInGroupClassName: 'lst'
                 }
@@ -182,10 +224,10 @@ define([
             expect(table.$('thead tr:eq(1) th:eq(1)').attr('class')).toEqual('lst');
             expect(table.$('thead tr:eq(1) th:eq(2)').attr('class')).toBeFalsey();
             expect(table.$('thead tr:eq(1) th:eq(3)').attr('class')).toEqual('lst');
-            expect(table.$('tbody tr:first td:eq(0)').attr('class')).toBeFalsey();
-            expect(table.$('tbody tr:first td:eq(1)').attr('class')).toEqual('lst');
-            expect(table.$('tbody tr:first td:eq(2)').attr('class')).toBeFalsey();
-            expect(table.$('tbody tr:first td:eq(3)').attr('class')).toEqual('lst');
+            expect(table.$('tbody tr:first td:eq(0)').attr('class')).toEqual('cell');
+            expect(table.$('tbody tr:first td:eq(1)').attr('class')).toEqual('cell lst');
+            expect(table.$('tbody tr:first td:eq(2)').attr('class')).toEqual('cell');
+            expect(table.$('tbody tr:first td:eq(3)').attr('class')).toEqual('cell lst');
         });
         it('can add a classname to the last cell in every column group, regardless of disabled state', function(){
             table = tabler.create([
@@ -195,6 +237,7 @@ define([
                 {id: 4, field: 'column2', name: 'Column 2b', groupName: 'Group 2'}
             ], {
                 plugins: [columnGrouper],
+                cellClassName: 'cell',
                 columnGrouper: {
                     lastCellInGroupClassName: 'lst'
                 }
@@ -208,8 +251,91 @@ define([
 
             expect(table.$('thead tr:eq(1) th:eq(0)').attr('class')).toEqual('lst');
             expect(table.$('thead tr:eq(1) th:eq(1)').attr('class')).toEqual('lst');
-            expect(table.$('tbody tr:first td:eq(0)').attr('class')).toEqual('lst');
-            expect(table.$('tbody tr:first td:eq(1)').attr('class')).toEqual('lst');
+            expect(table.$('tbody tr:first td:eq(0)').attr('class')).toEqual('cell lst');
+            expect(table.$('tbody tr:first td:eq(1)').attr('class')).toEqual('cell lst');
+        });
+        it('can add a first/last classname to a cell from a column group with single column', function(){
+            table = tabler.create([
+                {id: 1, field: 'column1', name: 'Column 1a', groupName: 'Group 1'}
+            ], {
+                plugins: [columnGrouper],
+                cellClassName: 'cell',
+                columnGrouper: {
+                    firstCellInGroupClassName: 'fist',
+                    lastCellInGroupClassName: 'lst'
+                }
+            });
+
+            table.load([
+                {column1: 'column 1a', column2: 'column 2a'},
+                {column1: 'column 1b', column2: 'column 2b'}
+            ]);
+            table.render();
+
+            expect(table.$('thead tr:eq(1) th:eq(0)').attr('class')).toEqual('fist lst');
+            expect(table.$('tbody tr:first td:eq(0)').attr('class')).toEqual('cell fist lst');
+        });
+        it('can add classnames when all are set at the same time', function(){
+            table = tabler.create([
+                {id: 1, field: 'column1', name: 'Column 1a', groupName: 'Group 1'},
+                {id: 2, field: 'column2', name: 'Column 2a', groupName: 'Group 1'},
+                {id: 3, field: 'column1', name: 'Column 1b', groupName: 'Group 2'},
+                {id: 4, field: 'column2', name: 'Column 2b', groupName: 'Group 2'},
+                {id: 5, field: 'lonelycolumn', name: 'Lonely Column', groupName: 'Lonely Group'}
+            ], {
+                plugins: [columnGrouper],
+                cellClassName: 'cell',
+                columnGrouper: {
+                    groupHeaderCellClassName: 'columngroupheader',
+                    firstCellInGroupClassName: 'fist',
+                    lastCellInGroupClassName: 'lst'
+                }
+            });
+
+            table.load([
+                {column1: 'column 1a', column2: 'column 2a'},
+                {column1: 'column 1b', column2: 'column 2b'}
+            ]);
+            table.render();
+
+            expect(table.$('thead tr:eq(0) th:eq(0)').attr('class')).toEqual('group-1 columngroupheader');
+            expect(table.$('thead tr:eq(0) th:eq(1)').attr('class')).toEqual('group-2 columngroupheader');
+            expect(table.$('thead tr:eq(0) th:eq(2)').attr('class')).toEqual('lonely-group columngroupheader');
+            expect(table.$('thead tr:eq(1) th:eq(0)').attr('class')).toEqual('fist');
+            expect(table.$('thead tr:eq(1) th:eq(1)').attr('class')).toEqual('lst');
+            expect(table.$('thead tr:eq(1) th:eq(2)').attr('class')).toEqual('fist')
+            expect(table.$('thead tr:eq(1) th:eq(3)').attr('class')).toEqual('lst');
+            expect(table.$('thead tr:eq(1) th:eq(4)').attr('class')).toEqual('fist lst');
+            expect(table.$('tbody tr:first td:eq(0)').attr('class')).toEqual('cell fist');
+            expect(table.$('tbody tr:first td:eq(1)').attr('class')).toEqual('cell lst');
+            expect(table.$('tbody tr:first td:eq(2)').attr('class')).toEqual('cell fist');
+            expect(table.$('tbody tr:first td:eq(3)').attr('class')).toEqual('cell lst');
+            expect(table.$('tbody tr:first td:eq(4)').attr('class')).toEqual('cell fist lst');
+        });
+        it('adding classnames do not modify original colspec', function(){
+            var colSpec = [
+                {id: 1, field: 'column1', name: 'Column 1a', groupName: 'Group 1'},
+                {id: 2, field: 'column2', name: 'Column 2a', groupName: 'Group 1'},
+                {id: 3, field: 'column1', name: 'Column 1b', groupName: 'Group 2'},
+                {id: 4, field: 'column2', name: 'Column 2b', groupName: 'Group 2'}
+            ];
+            table = tabler.create(_.clone(colSpec), {
+                plugins: [columnGrouper],
+                cellClassName: 'cell',
+                columnGrouper: {
+                    groupHeaderCellClassName: 'columngroupheader',
+                    firstCellInGroupClassName: 'fist',
+                    lastCellInGroupClassName: 'lst'
+                }
+            });
+
+            table.load([
+                {column1: 'column 1a', column2: 'column 2a'},
+                {column1: 'column 1b', column2: 'column 2b'}
+            ]);
+            table.render();
+
+            expect(table.spec).toEqual(colSpec);
         });
     });
 });

--- a/test/tabler.tests.js
+++ b/test/tabler.tests.js
@@ -100,6 +100,21 @@ define([
                     expect(td.className.split(' ')).toContain('foo');
                 });
             });
+            it('cellClassName does not modify colSpec', function(){
+                table = tabler.create([
+                    {field: 'column1', className: 'bar'}
+                ], {
+                    cellClassName: 'foo'
+                });
+
+                table.load([
+                    {column1: 'column 1a', column2: 'column 2a'}
+                ]);
+
+                table.render();
+
+                expect(table.spec[0].className).toEqual('bar');
+            });
         });
         describe('specs', function(){
             it('does not allow duplicate fieldnames', function(){


### PR DESCRIPTION
- Fixed cases where the colSpec was overwritten. This happened when
  combining the class names from the columnGroups with "cellClassNames"
- Added new columnGroups option "groupHeaderCellClassName" that is set
  on all the column group header (not only specific ones), and can even be
  combined with the default generated group class names
- Fixed logic that adds first/last group column class names to not
  overwrite the colSpec
