### PR TITLE
REP-139 fix six page edge case

### DIFF
--- a/lib/tabler/tabler.pager.js
+++ b/lib/tabler/tabler.pager.js
@@ -76,7 +76,7 @@
                     }
                     pagerSpec.push({
                         pageIndex: 0,
-                        className: 'first' + (currentPage > 3 ? ' skipped' : ''),
+                        className: 'first' + (startAt > 1 ? ' skipped' : ''),
                         text: 1
                     });
                 }
@@ -93,7 +93,7 @@
             if(totalPages > 5 && !onLastPage){
                 pagerSpec.push({
                     pageIndex: (totalPages - 1),
-                    className: 'last' + (currentPage < (totalPages - 4) ? ' skipped' : ''),
+                    className: 'last' + (endAt < totalPages - 1 ? ' skipped' : ''),
                     text: totalPages
                 });
             }

--- a/test/tabler.pager.tests.js
+++ b/test/tabler.pager.tests.js
@@ -343,6 +343,18 @@ define([
                         expect(table.$('tfoot ol.pager li:not(.next):last').hasClass('skipped')).toEqual(true);
                     });
                 });
+                describe('"6 pages results', function(){
+                    beforeEach(function(){
+                        table.pager.pageSize = 42; // equals 6 pages
+                    });
+                    it('does not add "skipped" to any element on any page', function(){
+                        _.each([0,1,2,3,4,5], function(i) {
+                            table.pager.currentPage = i;
+                            table.render();
+                            expect(table.$('tfoot ol.pager li:not(.next, .prev).skipped').length).toEqual(0);
+                        });
+                    });
+                });
             });
         });
         describe('works with server-side paging', function(){


### PR DESCRIPTION
For 6 result pages, being on page 1 rendered dots between 5 and 6 and on
being on page 6 rendered dots between 1 and 2.

Fixed that so the dots will now only be drawn, when there is
actually a page between skipped.

@spmason please review

should I increase the version too?

thanks
