### PR TITLE
Added overridable renderFootTr

### DIFF
--- a/lib/tabler/tabler.aggregator.js
+++ b/lib/tabler/tabler.aggregator.js
@@ -42,7 +42,7 @@
             table.renderFoot = function(data, spec){
                 var foot = renderFoot.apply(this, arguments);
                 if(_(spec).any(function(col){return !!col.aggregator;})){
-                    foot = ['<tr>'].concat(_(spec).map(function(spec){
+                    foot = [table.renderFootTr()].concat(_(spec).map(function(spec){
                             if(spec.aggregatorText){
                                 return table.makeTag('td', spec.aggregatorText, table.makeColumnAttrs(spec));
                             }

--- a/lib/tabler/tabler.js
+++ b/lib/tabler/tabler.js
@@ -418,6 +418,9 @@ MicroEvent.mixin    = function(destObject){
         renderBodyTr: function(/*row*/){
             return '<tr>';
         },
+        renderFootTr: function(){
+            return '<tr>';
+        },
         /*
          * Renders row(s) for the tbody of the table
          *

--- a/lib/tabler/tabler.pager.js
+++ b/lib/tabler/tabler.pager.js
@@ -50,7 +50,7 @@
                 endAt = Math.min(totalPages, startAt + 6),
                 onLastPage = (currentPage === totalPages - 1),
                 pagerSpec = [],
-                pagerHtml = (spec ? ['<tr>', '<td colspan="' + spec.length + '">'] : []).concat(
+                pagerHtml = (spec ? [table.renderFootTr(), '<td colspan="' + spec.length + '">'] : []).concat(
                     ['<ol class=pager>']
                 );
 

--- a/test/tabler.aggregator.tests.js
+++ b/test/tabler.aggregator.tests.js
@@ -111,5 +111,29 @@ define([
             expect(table.$('tfoot td').eq(2).hasClass('tablecell')).toEqual(true);
             expect(table.$('tfoot td').eq(2).hasClass('nonAggregateColumn')).toEqual(true);
         });
+        it('calls renderFootTr on render', function(){
+            var totaliser = function(memo, value){
+                    memo = memo + value;
+                    return memo;
+                };
+            table = tabler.create([
+                {field: 'column1', className: 'firstColumn', aggregatorText: 'Total'},
+                {field: 'column2', className: 'secondColumn', aggregator: totaliser}
+            ], {plugins: [aggregator]});
+
+            table.renderFootTr = function(){
+                return '<tr class="rabbitfoot">';
+            };
+
+            table.load([
+                {column1: 2},
+                {column1: 4}
+            ]);
+            table.render();
+
+            expect(table.$('tfoot tr.rabbitfoot').length).toEqual(1);
+            // didn't render this anywhere else
+            expect(table.$('.rabbitfoot').length).toEqual(1);
+        });
     });
 });

--- a/test/tabler.pager.tests.js
+++ b/test/tabler.pager.tests.js
@@ -111,6 +111,17 @@ define([
             expect(table.$('tfoot tr td ol.pager li:last').text()).toEqual('3');
             expect(table.$('tfoot tr td ol.pager li:last').data('page')).toEqual(2);
         });
+        it('calls renderFootTr on render', function(){
+            table.renderFootTr = function(){
+                return '<tr class="rabbitfoot">';
+            };
+           
+            table.render(); 
+
+            expect(table.$('tfoot tr.rabbitfoot').length).toEqual(1);
+            // didn't render this anywhere else
+            expect(table.$('.rabbitfoot').length).toEqual(1);
+        });
         describe('links when lots of pages', function(){
             var testData = (function generateData(i, data){
                 if(i-- === 0){


### PR DESCRIPTION
Updated aggregator and pager plugins to call tabler.renderFootTr when
rendering the footer.
This makes it possible to customize the "tr" in the footer, just like
the ones in the header of body.
