### PR TITLE
Fixed pageSize plugin when used outside a table, but rendered from the pagee

### DIFF
--- a/lib/tabler/tabler.pageSize.js
+++ b/lib/tabler/tabler.pageSize.js
@@ -42,11 +42,19 @@
             this.pager = table.pager;
 
             var renderPager = this.originalRenderPager = this.pager.renderPager;
-            table.pager.renderPager = function(){
+            table.pager.renderPager = function(table, data, spec){
                 var pager = renderPager.apply(this, arguments),
                     html = self.render();
 
-                return pager.replace('</td>', html + '</td>');
+                if (spec){
+                    // table mode
+                    html = pager.replace('</td>', html + '</td>');
+                }
+                else{
+                    // non-table mode
+                    html = pager + html;
+                }
+                return html;
             };
 
             table.$el.on('change', 'p.pageSize select', function(){

--- a/test/tabler.pageSize.tests.js
+++ b/test/tabler.pageSize.tests.js
@@ -110,6 +110,31 @@ define([
                 expect($pageSize.hasClass('pageSize')).toEqual(true);
                 expect($pageSize.find('select option').length).toEqual(3);
             });
+            it('can be used when rendered from pager', function(){
+                var PageSize = pageSize,
+                    Pager = pager,
+                    p = new Pager(),
+                    ps = new PageSize(),
+                    $pager,
+
+                    $div = $('<div />'),
+                    instance = {
+                        $el: $div,
+                        pager: p
+                    };
+
+                p.attach(instance);
+                ps.attach(instance);
+
+                p.currentPage = 3;
+                p.totalResults = 10;
+
+                $pager = $(p.render());
+
+                expect($pager.is('p')).toEqual(true);
+                expect($pager.hasClass('pageSize')).toEqual(true);
+                expect($pager.find('select option').length).toEqual(3);
+            });
         });
     });
 });


### PR DESCRIPTION
The renderPager() override was assuming that pager is always rendered
inside a table. Fixed it to make sure it still appends the pageSize
markup correctly when outside a table.

Note that this is how it is used in the app at some point. And I'm not able to fix that part of the app without further risk of breakge.

When fixing https://github.com/BrandwatchLtd/tabler/commit/0585e59ebd82143271745f901fb1e87e59698bce it uncovered this bug.
