### PR TITLE
Added global options for row class names

### DIFF
--- a/lib/tabler/tabler.js
+++ b/lib/tabler/tabler.js
@@ -122,6 +122,7 @@ MicroEvent.mixin    = function(destObject){
         this._plugins = [];
 
         this.cellClassName = options && options.cellClassName;
+        this.headerCellClassName = options && options.headerCellClassName;
         this.headRowClassName = options && options.headRowClassName;
         this.bodyRowClassName = options && options.bodyRowClassName;
         this.footRowClassName = options && options.footRowClassName;
@@ -276,9 +277,13 @@ MicroEvent.mixin    = function(destObject){
         },
 
         makeHeaderAttrs: function(colSpec){
+            var className = (colSpec.headerClassName || colSpec.className || '');
+            if(this.headerCellClassName){
+                className += ' ' + this.headerCellClassName;
+            }
             return {
                 width: colSpec.width,
-                'class': (colSpec.headerClassName || colSpec.className || '').trim()
+                'class': className.trim()
             };
         },
         /*

--- a/test/tabler.tests.js
+++ b/test/tabler.tests.js
@@ -83,7 +83,7 @@ define([
                 expect(table.$('tr').eq(5).find('td').eq(0).text()).toEqual('false');
                 expect(table.$('tr').eq(6).find('td').eq(0).text()).toEqual('0');
             });
-            it('can have a global className override for cells', function(){
+            it('can have a global className addition for cells', function(){
                 table = tabler.create([
                     {field: 'column1'}
                 ], {
@@ -114,6 +114,23 @@ define([
                 table.render();
 
                 expect(table.spec[0].className).toEqual('bar');
+            });
+            it('can have a global className addition override for header cells', function(){
+                table = tabler.create([
+                    {field: 'column1'}
+                ], {
+                    headerCellClassName: 'foo'
+                });
+
+                table.load([
+                    {column1: 'column 1a', column2: 'column 2a'}
+                ]);
+
+                table.render();
+
+                _(table.$('thead th')).forEach(function(th){
+                    expect(th.className.split(' ')).toContain('foo');
+                });
             });
         });
         describe('specs', function(){


### PR DESCRIPTION
Added headRowClassName, bodyRowClassName and footRowClassName as global
options. These will be set on the "<tr>" elements when rendering rows.

Please also bump up the tabler version to 0.10.11 after merging.
