### PR TITLE
tabler.update now does partial updates on the cell level

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,16 @@ It supports the following set of parameters:
 * className: A CSS classname to put on the <table> element
 * fetch: A function(options, callback) that will be called during `render` to fetch the data to be displayed.  If this is given the `load` method will have no effect and you will be responsible for applying paging, sorting etc - you will be supplied the necessary values through the `options` hash.  When you are ready to call back with the data to render, you can call `callback` with an object with an `items` array of the returned results and a `totalResults` value which is the total number of results in the overall results set (ie not just the current page but *all* items across all pages)
 
-### Additional Methods
 
-* update(index, object): update the row at `index` with the data given in `object`, allows you to partially update one row of the table at a time
+### Partial updates of rows
+
+Call `update(index, object, options)` to update the row at `index` with the data given in `object`, allows you to partially update one row of the table at a time
+
+The updates are actually applied at a _td_ level, by inspecting the fields given in `object` and only updating cells with a `field` set to those values.
+
+This can cause issues if you have a customer `formatter` that looks at other fields, so you can use the `updateFields` property to give tabler an extra *hint* about which columns should update
+
+If you want to turn this off completely, and force a re-render of the entire row, pass `invalidateRow: true` in the `options`
 
 ## Using Plugins
 

--- a/lib/tabler/tabler.js
+++ b/lib/tabler/tabler.js
@@ -345,11 +345,25 @@ MicroEvent.mixin    = function(destObject){
             this.$el.addClass('loading');
             this.fetch(options, _(this.renderTable).bind(this));
         },
-        update: function(index, newItem){
+        update: function(index, newItem, options){
             var spec = this.getSpec(),
-                html = this.renderRow(newItem, index, spec);
+                $row = this.$('tbody tr').eq(index),
+                $tds, updateFieldNames = Object.keys(newItem);
 
-            this.$('tbody tr').eq(index).replaceWith(html);
+            if(options && options.invalidateRow){
+                return $row.replaceWith(this.renderRow(newItem, index, spec));
+            }
+            $tds = $row.find('td');
+
+            _(spec).forEach(function(spec, index){
+                if(spec.disabled){
+                    return;
+                }
+                var fields = [spec.field].concat(spec.updateFields || []);
+                if(_.intersection(updateFieldNames, fields).length > 0){
+                    $tds.eq(index).replaceWith(this.renderCell(newItem, spec, index));
+                }
+            }, this);
         },
         renderTable: function(data){
             var spec = this.getSpec(data),

--- a/test/tabler.tests.js
+++ b/test/tabler.tests.js
@@ -500,7 +500,7 @@ define([
                 expect(table.$('tbody tr:eq(1) td:eq(1)').text()).toEqual('column 2b');
                 expect(table.$('tbody tr:eq(1) td:eq(2)').text()).toEqual('column 3b');
             });
-            it('only touches the row at the given index when updating', function(){
+            it('does not replace the rows when updating', function(){
                 var $row1 = table.$('tbody tr:eq(0)'),
                     $row2 = table.$('tbody tr:eq(1)');
 
@@ -510,8 +510,54 @@ define([
                     column3: 'updated column 3a'
                 });
 
+                expect($row1.parent().length).toEqual(1);
+                expect($row2.parent().length).toEqual(1);
+            });
+            it('only touches the cells that have changed', function(){
+                table.$('tbody tr:eq(0) td:eq(0)').text('modified column 1a');
+
+                table.update(0, {
+                    column3: 'updated column 3a'
+                });
+
+                expect(table.$('tbody tr:eq(0) td:eq(0)').text()).toEqual('modified column 1a');
+                expect(table.$('tbody tr:eq(0) td:eq(1)').text()).toEqual('column 2a');
+                expect(table.$('tbody tr:eq(0) td:eq(2)').text()).toEqual('updated column 3a');
+            });
+            it('updates other cells which have an updateFields property containing the modified field name', function(){
+                table.$('tbody tr:eq(0) td:eq(0)').text('modified column 1a');
+
+                table.spec[0].updateFields = ['otherColumn'];
+                table.spec[0].formatter = function(value, spec, row){
+                    return row.otherColumn;
+                };
+
+                table.update(0, {
+                    otherColumn: 'another column',
+                    column3: 'updated column 3a'
+                });
+
+                expect(table.$('tbody tr:eq(0) td:eq(0)').text()).toEqual('another column');
+                expect(table.$('tbody tr:eq(0) td:eq(1)').text()).toEqual('column 2a');
+                expect(table.$('tbody tr:eq(0) td:eq(2)').text()).toEqual('updated column 3a');
+            });
+            it('replaces the entire row when updating with invalidateRow: true', function(){
+                var $row1 = table.$('tbody tr:eq(0)'),
+                    $row2 = table.$('tbody tr:eq(1)');
+
+                table.update(0, {
+                    column1: 'updated column 1a',
+                    column2: 'updated column 2a',
+                    column3: 'updated column 3a'
+                }, {invalidateRow: true});
+
+                // Row 1 has been replaced with a new version
                 expect($row1.parent().length).toEqual(0);
                 expect($row2.parent().length).toEqual(1);
+
+                expect(table.$('tbody tr:eq(0) td:eq(0)').text()).toEqual('updated column 1a');
+                expect(table.$('tbody tr:eq(0) td:eq(1)').text()).toEqual('updated column 2a');
+                expect(table.$('tbody tr:eq(0) td:eq(2)').text()).toEqual('updated column 3a');
             });
         });
         describe('dynamic data', function(){


### PR DESCRIPTION
Rather than updating the whole row at a time (which is still an option)
