### PR TITLE
Previous change to support custom classes broke pager clicks.

### DIFF
--- a/lib/tabler/tabler.pager.js
+++ b/lib/tabler/tabler.pager.js
@@ -171,10 +171,17 @@
                 };
             }
 
-            table.$el.delegate('ol.pager li', 'click', function(e){
+            table.$el.delegate('ol li', 'click.pager', function(e){
+                var $target = $(e.target),
+                    page;
+
+                if(!$target.closest('ol').hasClass(self.cssClass)){
+                    return;
+                }
+
                 e.preventDefault();
 
-                var page = $(e.target).closest('li').data('page');
+                page = $target.closest('li').data('page');
 
                 self.updatePaging({
                     currentPage: page
@@ -187,7 +194,7 @@
             table.render = this.originalRender;
             this.originalRender = undefined;
 
-            table.$el.off('click', 'ol.pager li');
+            table.$el.off('click.pager', 'ol li');
         }
     });
 

--- a/test/tabler.pager.tests.js
+++ b/test/tabler.pager.tests.js
@@ -90,6 +90,27 @@ define([
                 pageSize: 2
             });
         });
+
+        it('triggers "paged" events on clicking page links, when the pager has a custom css class', function(){
+            var pagedSpy = sinon.spy(),
+                customClassName = 'fancyPantsClassName';
+
+            table.pager.cssClass = customClassName;
+
+            table.bind('paged', pagedSpy);
+            table.pager.pageSize = 2;
+
+            table.render();
+
+            table.$('tfoot tr td ol.' + customClassName +  ' li[data-page=1]').click();
+
+            expect(pagedSpy.calledOnce).toEqual(true);
+            expect(pagedSpy.args[0][0]).toEqual({
+                currentPage: 1,
+                pageSize: 2
+            });
+        });
+
         it('renders Previous link when on page > 1', function(){
             table.pager.pageSize = 2;
 


### PR DESCRIPTION
@spmason

This got a bit fiddly - the click event was bound before the class might be changed by the consuming code. So, it seemed easiest to check the target in the handler itself.

This left a problem with .off()ing the handler, so I used a namespace for the click handlers.

Let me know what you think.
