### PR TITLE
Preventing tabler from updating rows of possible inner tables

### DIFF
--- a/lib/tabler/tabler.js
+++ b/lib/tabler/tabler.js
@@ -347,7 +347,7 @@ MicroEvent.mixin    = function(destObject){
         },
         update: function(index, newItem, options){
             var spec = this.getSpec(),
-                $row = this.$('tbody tr').eq(index),
+                $row = this.$('> tbody tr').eq(index),
                 $tds, updateFieldNames = Object.keys(newItem);
 
             if(options && options.invalidateRow){

--- a/test/tabler.tests.js
+++ b/test/tabler.tests.js
@@ -1,7 +1,8 @@
 define([
-        'lib/tabler/tabler'
-        ],
-    function(tabler){
+    'lib/tabler/tabler'
+], function(
+    tabler
+){
     'use strict';
     describe('tabler', function(){
         var table;
@@ -493,16 +494,16 @@ define([
                     column3: 'updated column 3a'
                 });
 
-                expect(table.$('tbody tr:eq(0) td:eq(0)').text()).toEqual('updated column 1a');
-                expect(table.$('tbody tr:eq(0) td:eq(1)').text()).toEqual('updated column 2a');
-                expect(table.$('tbody tr:eq(0) td:eq(2)').text()).toEqual('updated column 3a');
-                expect(table.$('tbody tr:eq(1) td:eq(0)').text()).toEqual('column 1b');
-                expect(table.$('tbody tr:eq(1) td:eq(1)').text()).toEqual('column 2b');
-                expect(table.$('tbody tr:eq(1) td:eq(2)').text()).toEqual('column 3b');
+                expect(table.$('> tbody tr:eq(0) td:eq(0)').text()).toEqual('updated column 1a');
+                expect(table.$('> tbody tr:eq(0) td:eq(1)').text()).toEqual('updated column 2a');
+                expect(table.$('> tbody tr:eq(0) td:eq(2)').text()).toEqual('updated column 3a');
+                expect(table.$('> tbody tr:eq(1) td:eq(0)').text()).toEqual('column 1b');
+                expect(table.$('> tbody tr:eq(1) td:eq(1)').text()).toEqual('column 2b');
+                expect(table.$('> tbody tr:eq(1) td:eq(2)').text()).toEqual('column 3b');
             });
             it('does not replace the rows when updating', function(){
-                var $row1 = table.$('tbody tr:eq(0)'),
-                    $row2 = table.$('tbody tr:eq(1)');
+                var $row1 = table.$('> tbody tr:eq(0)'),
+                    $row2 = table.$('> tbody tr:eq(1)');
 
                 table.update(0, {
                     column1: 'updated column 1a',
@@ -514,18 +515,18 @@ define([
                 expect($row2.parent().length).toEqual(1);
             });
             it('only touches the cells that have changed', function(){
-                table.$('tbody tr:eq(0) td:eq(0)').text('modified column 1a');
+                table.$('> tbody tr:eq(0) td:eq(0)').text('modified column 1a');
 
                 table.update(0, {
                     column3: 'updated column 3a'
                 });
 
-                expect(table.$('tbody tr:eq(0) td:eq(0)').text()).toEqual('modified column 1a');
-                expect(table.$('tbody tr:eq(0) td:eq(1)').text()).toEqual('column 2a');
-                expect(table.$('tbody tr:eq(0) td:eq(2)').text()).toEqual('updated column 3a');
+                expect(table.$('> tbody tr:eq(0) td:eq(0)').text()).toEqual('modified column 1a');
+                expect(table.$('> tbody tr:eq(0) td:eq(1)').text()).toEqual('column 2a');
+                expect(table.$('> tbody tr:eq(0) td:eq(2)').text()).toEqual('updated column 3a');
             });
             it('updates other cells which have an updateFields property containing the modified field name', function(){
-                table.$('tbody tr:eq(0) td:eq(0)').text('modified column 1a');
+                table.$('> tbody tr:eq(0) td:eq(0)').text('modified column 1a');
 
                 table.spec[0].updateFields = ['otherColumn'];
                 table.spec[0].formatter = function(value, spec, row){
@@ -537,13 +538,13 @@ define([
                     column3: 'updated column 3a'
                 });
 
-                expect(table.$('tbody tr:eq(0) td:eq(0)').text()).toEqual('another column');
-                expect(table.$('tbody tr:eq(0) td:eq(1)').text()).toEqual('column 2a');
-                expect(table.$('tbody tr:eq(0) td:eq(2)').text()).toEqual('updated column 3a');
+                expect(table.$('> tbody tr:eq(0) td:eq(0)').text()).toEqual('another column');
+                expect(table.$('> tbody tr:eq(0) td:eq(1)').text()).toEqual('column 2a');
+                expect(table.$('> tbody tr:eq(0) td:eq(2)').text()).toEqual('updated column 3a');
             });
             it('replaces the entire row when updating with invalidateRow: true', function(){
-                var $row1 = table.$('tbody tr:eq(0)'),
-                    $row2 = table.$('tbody tr:eq(1)');
+                var $row1 = table.$('> tbody tr:eq(0)'),
+                    $row2 = table.$('> tbody tr:eq(1)');
 
                 table.update(0, {
                     column1: 'updated column 1a',
@@ -555,9 +556,9 @@ define([
                 expect($row1.parent().length).toEqual(0);
                 expect($row2.parent().length).toEqual(1);
 
-                expect(table.$('tbody tr:eq(0) td:eq(0)').text()).toEqual('updated column 1a');
-                expect(table.$('tbody tr:eq(0) td:eq(1)').text()).toEqual('updated column 2a');
-                expect(table.$('tbody tr:eq(0) td:eq(2)').text()).toEqual('updated column 3a');
+                expect(table.$('> tbody tr:eq(0) td:eq(0)').text()).toEqual('updated column 1a');
+                expect(table.$('> tbody tr:eq(0) td:eq(1)').text()).toEqual('updated column 2a');
+                expect(table.$('> tbody tr:eq(0) td:eq(2)').text()).toEqual('updated column 3a');
             });
         });
         describe('dynamic data', function(){


### PR DESCRIPTION
If the user added another table anywhere insed the tabler, then the `update` would faild as `$('tbody tr')` would find the wrong element...
