### PR TITLE
pass row index instead of cell index to .renderCell()

### DIFF
--- a/lib/tabler/tabler.js
+++ b/lib/tabler/tabler.js
@@ -345,23 +345,23 @@ MicroEvent.mixin    = function(destObject){
             this.$el.addClass('loading');
             this.fetch(options, _(this.renderTable).bind(this));
         },
-        update: function(index, newItem, options){
+        update: function(rowIndex, newItem, options){
             var spec = this.getSpec(),
-                $row = this.$('> tbody tr').eq(index),
+                $row = this.$('> tbody tr').eq(rowIndex),
                 $tds, updateFieldNames = Object.keys(newItem);
 
             if(options && options.invalidateRow){
-                return $row.replaceWith(this.renderRow(newItem, index, spec));
+                return $row.replaceWith(this.renderRow(newItem, rowIndex, spec));
             }
             $tds = $row.find('td');
 
-            _(spec).forEach(function(spec, index){
+            _(spec).forEach(function(spec, cellIndex){
                 if(spec.disabled){
                     return;
                 }
                 var fields = [spec.field].concat(spec.updateFields || []);
                 if(_.intersection(updateFieldNames, fields).length > 0){
-                    $tds.eq(index).replaceWith(this.renderCell(newItem, spec, index));
+                    $tds.eq(cellIndex).replaceWith(this.renderCell(newItem, spec, rowIndex));
                 }
             }, this);
         },

--- a/test/tabler.tests.js
+++ b/test/tabler.tests.js
@@ -560,6 +560,24 @@ define([
                 expect(table.$('> tbody tr:eq(0) td:eq(1)').text()).toEqual('updated column 2a');
                 expect(table.$('> tbody tr:eq(0) td:eq(2)').text()).toEqual('updated column 3a');
             });
+            it('passes row index to renderCell', function(){
+                var renderCellSpy = sinon.spy(table, 'renderCell');
+                table.update(1, {
+                    column1: 'updated column 1b'
+                });
+
+                expect(renderCellSpy.calledOnce).toEqual(true);
+                expect(renderCellSpy.args[0][2]).toEqual(1);
+
+                table.update(0, {
+                    column3: 'updated column 3a'
+                });
+
+                expect(renderCellSpy.calledTwice).toEqual(true);
+                expect(renderCellSpy.args[1][2]).toEqual(0);
+
+                renderCellSpy.restore();
+            });
         });
         describe('dynamic data', function(){
             it('calls "fetch" method on render if specified', function(){


### PR DESCRIPTION
When updating with `update` a cell the cell index was passed to the formatter, instead of the row index. The code path of `renderRow` does also pass the row index.

@spmason @mroderick or @grahamscott please review and create a new version
Thanks!
