### PR TITLE
If a fetch parameter is supplied, don't let plugins interfere with sorting and paging

### DIFF
--- a/lib/tabler/tabler.js
+++ b/lib/tabler/tabler.js
@@ -148,16 +148,22 @@ MicroEvent.mixin    = function(destObject){
 
         options = options || {};
 
-        for(i = 0; i < plugins.length; i++){
-            table.addPlugin(plugins[i], options[plugins[i].pluginName]);
-        }
-
         if(options.className){
             table.$el.addClass(options.className);
         }
 
         if(options.fetch){
-            table.fetch = options.fetch;
+            Object.defineProperty(table, "fetch", {
+              configurable: false,
+              get: function(value) {
+                return options.fetch;
+              },
+              set: function(){}
+            });
+        }
+
+        for(i = 0; i < plugins.length; i++){
+            table.addPlugin(plugins[i], options[plugins[i].pluginName]);
         }
 
         if(spec){

--- a/test/tabler.tests.js
+++ b/test/tabler.tests.js
@@ -663,6 +663,22 @@ define([
 
                 expect(table.$el.hasClass('loading')).toEqual(false);
             });
+            it('if a fetch parameter is specified, it cannot be overridden / redefined', function(){
+                var fetchSpy = sinon.spy(),
+                    redefinedFetchSpy = sinon.spy(),
+                    table = tabler.create({
+                        fetch: fetchSpy
+                    });
+
+                table.render();
+                expect(fetchSpy.callCount).toEqual(1);
+
+                table.fetch = redefinedFetchSpy;
+
+                table.render();
+                expect(fetchSpy.callCount).toEqual(2);
+                expect(redefinedFetchSpy.callCount).toEqual(0);
+            });
         });
         describe('plugins', function(){
             it('can create with plugins', function(){


### PR DESCRIPTION
In compliance with the [documentation](https://github.com/BrandwatchLtd/tabler/blame/master/README.md#L90)

Please note that this particular feature requires IE > 8.
