### PR TITLE
Fix click handling on sortable columns

### DIFF
--- a/lib/tabler/tabler.sortable.js
+++ b/lib/tabler/tabler.sortable.js
@@ -118,8 +118,6 @@
                     field = $a.data('sort-key'),
                     direction = $th.hasClass('sorted-asc') ? 'desc' : $th.hasClass('sorted-desc') ? 'asc' : 'desc';
 
-                e.preventDefault();
-
                 if(!$target.is($th) && $target.closest('.sort').length === 0){
                     return;
                 }
@@ -127,6 +125,8 @@
                 if(!$a.length){
                     return;
                 }
+
+                e.preventDefault();
 
                 self.field = field;
                 self.direction = direction;

--- a/test/tabler.sortable.tests.js
+++ b/test/tabler.sortable.tests.js
@@ -85,9 +85,35 @@ define([
             ]);
             table.render();
 
-            table.$('thead th:first a.sort span.betaIcon').trigger(event);
+            table.$('thead th:first a.sort').trigger(event);
 
             expect(event.isDefaultPrevented()).toEqual(true);
+        });
+        it('does not prevent default if a different anchor is clicked', function(){
+            var event = jQuery.Event('click'),
+                anchor = $('<a href="#">Remove</a>');
+
+            table = tabler.create([
+                {
+                    field: 'column1',
+                    sortable: true,
+                    headerFormatter: function(colSpec, title){
+                        return title + ' <span title="This feature is in BETA" class="betaIcon"></span>';
+                    }
+                }
+            ], {plugins: [sortable]}),
+
+            table.load([
+                {column1: 30},
+                {column1: 10},
+                {column1: 20}
+            ]);
+            table.render();
+
+            table.$('thead th:first').append(anchor);
+            anchor.trigger(event);
+
+            expect(event.isDefaultPrevented()).toEqual(false);
         });
         it('client-side sorts descending on first header click', function(){
             table = tabler.create([


### PR DESCRIPTION
Currently if a sortable column uses child elements in a headerFormatter such as a `<span/>` this will not trigger the sort, because the handler is explicitly looking for an anchor.

We now check the click target and parent elements for the `.sort` class to fix this behaviour. Also we no longer prevent the default event unless we are actually handling the event ourselves. This allows the heading to contain other anchors that can open external urls etc. 
