### PR TITLE
Fixed bad escaping of arrays of values in tabler.formatValue

### DIFF
--- a/lib/tabler/tabler.js
+++ b/lib/tabler/tabler.js
@@ -325,7 +325,14 @@ MicroEvent.mixin    = function(destObject){
             if(value === '' || value === undefined || value === null || _.isNaN(value)){
                 value = colSpec.defaultText || value;
             }
-            value = _.escape(value);
+
+            if(_.isArray(value)){
+                value = _.map(value, function(v){
+                    return _.escape(v);
+                });
+            } else {
+                value = _.escape(value);
+            }
 
             if(typeof colSpec.formatter === 'function'){
                 value = colSpec.formatter.call(this, value, colSpec, row, index);

--- a/test/tabler.tests.js
+++ b/test/tabler.tests.js
@@ -94,6 +94,29 @@ define([
                 expect(table.$('tbody td:first').length).toEqual(1);
                 expect(table.$('tbody td:first').html()).toEqual('&lt;script&gt;alert("yolo");&lt;/script&gt;');
             });
+            it('escapes html entities in cells with arrays of values', function(){
+                var escapedHtml = '<ul><li>foo</li><li>&lt;script&gt;alert("yolo");&lt;/script&gt;</li></ul>';
+
+                table = tabler.create([{
+                    field: 'column1',
+                    formatter: function(value){
+                        var lis = _(value).map(function(val){
+                            return '<li>'+ val + '</li>';
+                        }).join('');
+
+                        return '<ul>' + lis + '</ul>';
+                    }
+                }]);
+
+                table.load([
+                    { column1: ['foo', '<script>alert("yolo");</script>' ] }
+                ]);
+
+                table.render();
+
+                expect(table.$('tbody td:first').length).toEqual(1);
+                expect(table.$('tbody td:first').html()).toEqual(escapedHtml);
+            });
             it('escapes html entities in cells for default values', function(){
                 table = tabler.create([
                     {field: 'column1', defaultText: '<script>alert("yolo");</script>'}


### PR DESCRIPTION
It looks like the XSS fixes in the recent release break formatters when an array is passed as the value. @spmason please review
