### PR TITLE
align standalone behaviour of jumpToPage with pageSize

### DIFF
--- a/lib/tabler/tabler.jumpToPage.js
+++ b/lib/tabler/tabler.jumpToPage.js
@@ -32,11 +32,19 @@
             this.pager = table.pager;
 
             var renderPager = this.originalRenderPager = this.pager.renderPager;
-            table.pager.renderPager = function(){
+            table.pager.renderPager = function(table, data, spec){
                 var pager = renderPager.apply(this, arguments),
                     html = self.render();
 
-                return pager.replace('</td>', html + '</td>');
+                if (spec){
+                    // table mode
+                    html = pager.replace('</td>', html + '</td>');
+                } else {
+                    // non-table mode
+                    html = pager + html;
+                };
+
+                return html;
             };
 
             function updatePageIndex(){

--- a/test/tabler.jumpToPage.tests.js
+++ b/test/tabler.jumpToPage.tests.js
@@ -135,5 +135,48 @@ define([
 
             renderStub.restore();
         });
+        describe('standalone', function() {
+            it('can be used without a tabler instance', function() {
+                var JumpToPage = jumpToPage,
+                    Pager = pager,
+                    p = new Pager(),
+                    jtp = new JumpToPage(),
+                    $jumpToPage;
+
+                jtp.attach({
+                    $el: $('<div />'),
+                    pager: p
+                });
+
+                $jumpToPage = $(jtp.render());
+
+                expect($jumpToPage.is('p')).toEqual(true);
+                expect($jumpToPage.hasClass('jumpToPage')).toEqual(true);
+            });
+
+            it('when attached renders in pager', function() {
+                var JumpToPage = jumpToPage,
+                    Pager = pager,
+                    p = new Pager(),
+                    jtp = new JumpToPage(),
+                    $pager,
+
+                    $div = $('<div />'),
+                    instance = {
+                        $el: $div,
+                        pager: p
+                    };
+
+                p.attach(instance);
+                jtp.attach(instance);
+
+                p.currentPage = 3;
+                p.totalResults = 10;
+
+                $pager = $('<div>' + p.render() + '</div>');
+
+                expect($pager.find('.jumpToPage').length).toEqual(1);
+            });
+        });
     });
 });


### PR DESCRIPTION
In https://github.com/BrandwatchLtd/tabler/pull/16 a fix was added to the `pageSize` plugin.

This PR applies the same fix to the `jumpToPage` plugin.