### PR TITLE
Upgraded dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "url": "git://github.com/BrandwatchLtd/tabler.git"
   },
   "scripts": {
+    "test": "./testem",
     "version": "node update-bower-version.js && git add bower.json"
   },
   "engines": {
@@ -21,9 +22,9 @@
   ],
   "dependencies": {},
   "devDependencies": {
-    "serve": "2.4.1",
-    "mocha": "3.2.0",
-    "testem": "1.14.2"
+    "mocha": "^5.2.0",
+    "serve": "^9.4.0",
+    "testem": "^2.9.0"
   },
   "optionalDependencies": {},
   "volo": {


### PR DESCRIPTION
mocha, serve and testem were all very out-of-date and have known security vulnerabilities